### PR TITLE
Update to V7 (for real this time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Prerequisite: Have a local clone of the Grayjay.Desktop source code. It is recom
 
 
 1. Verify the metadata has been updated in the main grayjay repo (mostly screenshots, but also release version numbers/dates/changelogs, and any store descriptions that need updating)
-2. Run `python3 ./scripts/flatpak-submodules-generator.py <path to your checked out grayjay source repo> <tag name to build, i.e. 7>` to update `submodule-sources.json`
-3. Start a build, and then stop it about 15-20 seconds after the grayjay module starts building. Then run `flatpak-builder --run build-dir ./app.grayjay.Grayjay.yaml ./scripts/npm-deps.sh npm-sources.json /run/build/grayjay/Grayjay.Desktop.Web/package-lock.json` to update the `npm-sources.json`
-4. Run `python3 ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py nuget-sources.json <path to your checked out grayjay source repo>/Grayjay.Desktop.sln --freedesktop 24.08 --dotnet 9` to update `nuget-sources.json`
-5. Ensure that the `commit` value of the first source under the `grayjay` module in `` has been updated to the commit hash corresponding to the git tag (or hotfix commit) you want to release.
+2. Ensure that the `commit` value of the first source under the `grayjay` module in `./app.grayjay.Grayjay.yaml` has been updated to the commit hash corresponding to the git tag (or hotfix commit) you want to release.
+3. Run `python3 ./scripts/flatpak-submodules-generator.py <path to your checked out grayjay source repo> <tag name to build, i.e. 7>` to update `submodule-sources.json`
+4. Start a build, and then stop it about 15-20 seconds after the grayjay module starts building. Then run `flatpak-builder --run build-dir ./app.grayjay.Grayjay.yaml ./scripts/npm-deps.sh npm-sources.json /run/build/grayjay/Grayjay.Desktop.Web/package-lock.json` to update the `npm-sources.json`
+5. Run `python3 ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py nuget-sources.json <path to your checked out grayjay source repo>/Grayjay.Desktop.sln --freedesktop 24.08 --dotnet 9` to update `nuget-sources.json`
 
 You should now be able to run `just build` to completion to make sure everything works or make any adjustments based on what changed in the specific version of Grayjay.
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ Prerequisite: Have a local clone of the Grayjay.Desktop source code. It is recom
 
 
 1. Verify the metadata has been updated in the main grayjay repo (mostly screenshots, but also release version numbers/dates/changelogs, and any store descriptions that need updating)
-2. update the version number in `app.grayjay.Grayjay.yaml` in the command args supplied to  `./deploy_flatpak.sh` (TODO: this should eventually be fetched from the tag name)
-3. Run `python3 ./scripts/flatpak-submodules-generator.py <path to your checked out grayjay source repo> <tag name to build, i.e. 7>` to update `submodule-sources.json`
-4. Start a build, and then stop it about 15-20 seconds after the grayjay module starts building. Then run `flatpak-builder --run build-dir ./app.grayjay.Grayjay.yaml ./scripts/npm-deps.sh npm-sources.json /run/build/grayjay/Grayjay.Desktop.Web/package-lock.json` to update the `npm-sources.json`
-5. Run `python3 ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py nuget-sources.json <path to your checked out grayjay source repo>/Grayjay.Desktop.sln --freedesktop 24.08 --dotnet 9` to update `nuget-sources.json`
-6. Ensure that the `commit` value of the first source under the `grayjay` module in `` has been updated to the commit hash corresponding to the git tag (or hotfix commit) you want to release.
+2. Run `python3 ./scripts/flatpak-submodules-generator.py <path to your checked out grayjay source repo> <tag name to build, i.e. 7>` to update `submodule-sources.json`
+3. Start a build, and then stop it about 15-20 seconds after the grayjay module starts building. Then run `flatpak-builder --run build-dir ./app.grayjay.Grayjay.yaml ./scripts/npm-deps.sh npm-sources.json /run/build/grayjay/Grayjay.Desktop.Web/package-lock.json` to update the `npm-sources.json`
+4. Run `python3 ./flatpak-builder-tools/dotnet/flatpak-dotnet-generator.py nuget-sources.json <path to your checked out grayjay source repo>/Grayjay.Desktop.sln --freedesktop 24.08 --dotnet 9` to update `nuget-sources.json`
+5. Ensure that the `commit` value of the first source under the `grayjay` module in `` has been updated to the commit hash corresponding to the git tag (or hotfix commit) you want to release.
 
 You should now be able to run `just build` to completion to make sure everything works or make any adjustments based on what changed in the specific version of Grayjay.
 

--- a/app.grayjay.Grayjay.yaml
+++ b/app.grayjay.Grayjay.yaml
@@ -38,7 +38,7 @@ modules:
         npm_config_cache: ${FLATPAK_BUILDER_BUILDDIR}/flatpak-node/npm-cache
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/grayjay
-      - ./deploy_flatpak.sh 7 "${FLATPAK_DEST}/grayjay" "${FLATPAK_BUILDER_BUILDDIR}/nuget-sources"
+      - ./deploy_flatpak.sh "${FLATPAK_DEST}/grayjay" "${FLATPAK_BUILDER_BUILDDIR}/nuget-sources"
       - dotnet nuget locals all --clear
       - install -Dm 0644 app.grayjay.Grayjay.desktop ${FLATPAK_DEST}/share/applications/app.grayjay.Grayjay.desktop
       - install -Dm 0644 app.grayjay.Grayjay.metainfo.xml  ${FLATPAK_DEST}/share/metainfo/app.grayjay.Grayjay.metainfo.xml

--- a/app.grayjay.Grayjay.yaml
+++ b/app.grayjay.Grayjay.yaml
@@ -59,7 +59,7 @@ modules:
         # use if developing locally, and adjust/remove branch/tag/commit below accordingly
         # url: file:///path/to/Grayjay.Desktop 
         url: https://gitlab.futo.org/videostreaming/Grayjay.Desktop.git
-        commit: a08fec17e82af352eb2ffb03b0410103075576cb
+        commit: 65f936305f7060353ca0030dbb7c738395e1504a
         disable-submodules: true
         # x-checker-data:
         #   type: git

--- a/deploy_flatpak.sh
+++ b/deploy_flatpak.sh
@@ -12,23 +12,19 @@
 # rather than trying to continue. See: https://stackoverflow.com/a/1379904/
 set -e
 
-if [[ "$1" != "" ]]; then
-   version="$1"
-else
-   echo -n "Version:"
-   read version
-fi
 
-if [[ "$2" != "" ]]; then
-  destination="$2"
+version=$(cat Grayjay.ClientServer/AppVersion.json | jq '.Version')
+
+if [[ "$1" != "" ]]; then
+  destination="$1"
 else
   echo -n "Install Destination:"
   read destination
 fi
 
 packagecache=""
-if [[ "$3" != "" ]]; then
-  packagecache="$3"
+if [[ "$2" != "" ]]; then
+  packagecache="$2"
 fi
 
 echo "$packagecache"


### PR DESCRIPTION
Ok so i made a pretty major oversight in #7.

I updated basically everything except the SHA of the Grayjay.Desktop repo to use.

So this caused the version number in the app to show as v7, but functionally (and according to the flathub store page) it was still v6. This would also manifest in sync features that are equally broken to v6 because thats the code that was in use

This PR changes that hash so that it correctly uses the actual V7 code